### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#3.10.0 (2013-09-17)
+# 3.10.0 (2013-09-17)
 Merged various pull requests including subfolders in beaker directory
 
 - Bumped version to 3.10.0 to prepare for release.
@@ -14,14 +14,14 @@ Merged various pull requests including subfolders in beaker directory
 - bump selenium-webdriver to overcome a loading error for rubyzip
 - Beaker directory now supports sub-directories
 
-#3.9.1 (2013-08-26)
+# 3.9.1 (2013-08-26)
 small fix to gemfile
 
 - Bumped version to 3.9.1 to prepare for release.
 - updated gemfile
 - removed dupe log from changelog
 
-#3.9.0 (2013-08-26)
+# 3.9.0 (2013-08-26)
 Improved reporting features and configuration for sauce permissions
 
 - gg
@@ -37,27 +37,27 @@ Improved reporting features and configuration for sauce permissions
 - removed specific log specification from system tests, cleaned up log configuration to just default to evidence and refactoried the cli a small bit to support it.
 - updated bundle and fixed new code quality error
 
-#3.9.0-rc.3 (2013-08-19)
+# 3.9.0-rc.3 (2013-08-19)
 - added toggle for parts of html reports
 - added a fix to allow jenkins ci server to show the html report images
 - integrated new selenium connect
 - updates to configurations
 - integrated optimizely opt out
 
-#3.9.0-rc.2 (2013-08-14)
+# 3.9.0-rc.2 (2013-08-14)
 - Added Basic Auth Support. Preserving release candidate numbering since there are improvements to be made to HTTP reporting
 
-#3.9.0-rc.1 (2013-08-12)
+# 3.9.0-rc.1 (2013-08-12)
 Release candidate with new features including
 - Consolidated html report
 - Updates to chemists to support multiple chemists from being joined
 
-###Known Issues
+### Known Issues
 - When running chrome locally the chromedriver logs do not always get placed in the correct places, likely due to the current approach of moving them around
 - There is a lack of sufficient tests around the reporting functionality, so there could be some sporadic behavior when it comes to the consolidation and formatting of the main html report
 - Configuration of specific log_path locations and output names is not fully supported at this time. Both an html report and junit.xml are output by default.
 
-#3.8.1 (2013-08-09)
+# 3.8.1 (2013-08-09)
 Cleaned up chemists to use same instance in the formulas and bug fixes
 
 - Bumped version to 3.8.1 to prepare for release.
@@ -65,7 +65,7 @@ Cleaned up chemists to use same instance in the formulas and bug fixes
 - updated tests and chemist to reflect the mutability of type but not key
 - improved chemists by ensuring the same chemist object is always in play so that different formulas that update it state work together, also fixed a small bug with the loading of formulas by name
 
-#3.8.0 (2013-08-05)
+# 3.8.0 (2013-08-05)
 Implemented the chemists feature to add user data management as well as a simplified strategy for loading formulas
 
 - Bumped version to 3.8.0 to prepare for release.
@@ -86,7 +86,7 @@ Implemented the chemists feature to add user data management as well as a simpli
 - updated selenium connect version
 - added animoto mention to friends section
 
-#3.7.0 (2013-07-24)
+# 3.7.0 (2013-07-24)
 updated evidence to put in test based folders and added configuration for the retry functionality
 
 - Bumped version to 3.7.0 to prepare for release.
@@ -98,7 +98,7 @@ updated evidence to put in test based folders and added configuration for the re
 - added retry to configuration file and run time parameters updated docs and tests
 - updated sc version
 
-#3.6.0 (2013-07-20)
+# 3.6.0 (2013-07-20)
 Added the ability for tests to be retried on failure. A single retry will be attempted by default and the output will be verbose.
 
 - Bumped version to 3.6.0 to prepare for release.
@@ -109,26 +109,26 @@ Added the ability for tests to be retried on failure. A single retry will be att
 - Added a config attribute to brew for verbose retry
 - Added rspec-retry
 
-#3.5.0 (2013-07-15)
+# 3.5.0 (2013-07-15)
 updated logging to store assets in a per beaker folder
 
 - Bumped version to 3.5.0 to prepare for release.
 - updated docs
 - updated ckit to use latest sc with cleaner log storage and added a flag for the screenshot download
 
-#3.4.2 (2013-07-14)
+# 3.4.2 (2013-07-14)
 fixed typo
 
 - Bumped version to 3.4.2 to prepare for release.
 - fixed dumb typo
 
-#3.4.1 (2013-07-14)
+# 3.4.1 (2013-07-14)
 minor update to sc
 
 - Bumped version to 3.4.1 to prepare for release.
 - bumped sc version for bug fix
 
-#3.4.0 (2013-07-14)
+# 3.4.0 (2013-07-14)
 upgrade to use new selenium connect and integrated sauce lab job failures screenshots and ci reporting
 
 - small patch to the rake file
@@ -142,7 +142,7 @@ upgrade to use new selenium connect and integrated sauce lab job failures screen
 - turned off travis email notifications
 - added dynamic naming for sauce runs, and a dump of the video url on failure
 
-#3.3.1 (2013-07-11)
+# 3.3.1 (2013-07-11)
 Fixed bugs related to tagging and alternate configuration files in concurrent runs
 
 - Bumped version to 3.3.1 to prepare for release.
@@ -150,7 +150,7 @@ Fixed bugs related to tagging and alternate configuration files in concurrent ru
 - fixed issue where --all was not getting passed forward in parallel tests and the same with an alternative config file, added tests for those as well
 - fixed duplicate alias for brew option
 
-#3.3.0 (2013-07-09)
+# 3.3.0 (2013-07-09)
 Fixed bugs with tagging and concurrency
 
 - Bumped version to 3.3.0 to prepare for release.
@@ -162,13 +162,13 @@ Fixed bugs with tagging and concurrency
 - removed debug info
 - initial cut on tagging updates
 
-#3.2.0 (2013-07-08)
+# 3.2.0 (2013-07-08)
 Updated Selenium Connect
 
 - Bumped version to 3.2.0 to prepare for release.
 - updated selenium connect to latest version
 
-#3.1.0 (2013-07-07)
+# 3.1.0 (2013-07-07)
 Updated logging mechanism for concurrent tests and to output junit xml.
 
 - Bumped version to 3.1.0 to prepare for release.
@@ -183,14 +183,14 @@ Updated logging mechanism for concurrent tests and to output junit xml.
 - added in configurable junit export with stdout
 - added logging feature and tests, and expanded the configuration for logging
 
-#3.0.1 (2013-07-05)
+# 3.0.1 (2013-07-05)
 Made the base url available in the env for formula usage
 
 - Bumped version to 3.0.1 to prepare for release.
 - removed unused shared context file, and updated config parameter passing
 - Added an environment variable setter for base_url based on the config object in a before(:each) block
 
-#3.0.0 (2013-07-04)
+# 3.0.0 (2013-07-04)
 Now with concurrent tests
 
 - Bumped version to 3.0.0 to prepare for release.
@@ -219,7 +219,7 @@ Now with concurrent tests
 - Downgraded the required ruby version to just 1.9.3
 - one small edit because of a bug with git flow #62
 
-#2.1.0 (2013-06-28)
+# 2.1.0 (2013-06-28)
 - Updated documentation for #62 release process.
 - Bumped version to 2.1.0 to prepare for release.
 - Changed the oder of branch updates in rakefile #62
@@ -230,20 +230,20 @@ Now with concurrent tests
 -  updated rvm version files and removed the ext directory
 - moved the build dir deletion to the before so that post test inspection could be carried out, also added a rough implementation to close #63
 
-#2.0.0 (2013-06-27)
+# 2.0.0 (2013-06-27)
 - Updated to Selenium-Connect version to 2.0.0
 - Improved performance with driver hooks
 - Added the ability to specify config files on brew.
 - NOTE: Updated default config file from `_config.yaml` to `config.yaml`
 - Added the "catalyst" concept for injecting data into formulas.
 
-#1.3.0 (2013-06-22)
+# 1.3.0 (2013-06-22)
 - Added explicit recursive file loading process for formulas
 - Cleaned up documentation
 - Updated tests
 - Cleaned up logging
 
-#1.2.1 (2013-06-21)
+# 1.2.1 (2013-06-21)
 - Bumping version number and adding Jason Fox as an author
 - Making it so symbol values as tags in beakers will default to true if no value is set to them
 - Pulled out the log value setter from shared_context and rolled this up into selenium-connect instead. Bumped to new version of selenium-connect to get this functionality
@@ -257,13 +257,13 @@ Now with concurrent tests
 - updated git ignore for build directory and changed the new feature to a different name to prevent conflicts
 - removed non running spec
 - added a few rake tasks and switched to standard build directory
-#1.1.1 (2013-06-09)
+# 1.1.1 (2013-06-09)
 - Bumping selenium-connect version to account for sauce gem breaking changes
 
-#1.1.0 (2013-06-09)
+# 1.1.0 (2013-06-09)
 - Added the ability to pass in environment variables with ckit brew --params=THING1:value THING2:value
 
-#1.0.0 (2013-06-05)
+# 1.0.0 (2013-06-05)
 - Removed a hard-coded exit code checker from the ckit binary, also adjusted the requires in it to use the top level chemistrykit file in lib. Had to rework that file as well. Also updated the readme
 - Looks like my previous commit didn't include the cleanup of old files. Here you go! Also, updated the readme slightly
 - Wired up selenium-connect and gladly gutted a heap of code that it replaced. Also, updated the readme and updated the gemspec.
@@ -311,7 +311,7 @@ Now with concurrent tests
 - Removed rake because we're not using it, added aruba and cucumber because living docs for the Cli is cool
 - Please load aruba when you run feature files
 
-#0.1.1 (2013-02-02)
+# 0.1.1 (2013-02-02)
 
 * `ckit new` generates a chemistrykit project
 * Execute tests in SauceLabs Ondemand

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ChemistryKit 3.10.0 (2013-09-17)
+# ChemistryKit 3.10.0 (2013-09-17)
 
 [![Gem Version](https://badge.fury.io/rb/chemistrykit.png)](http://badge.fury.io/rb/chemistrykit) [![Build Status](https://travis-ci.org/arrgyle/chemistrykit.png?branch=develop)](https://travis-ci.org/jrobertfox/chef-broiler-platter) [![Code Climate](https://codeclimate.com/github/arrgyle/chemistrykit.png)](https://codeclimate.com/github/arrgyle/chemistrykit) [![Coverage Status](https://coveralls.io/repos/arrgyle/chemistrykit/badge.png?branch=develop)](https://coveralls.io/r/arrgyle/chemistrykit?branch=develop)
 
@@ -19,7 +19,7 @@ All the documentation for ChemistryKit can be found in this README, organized as
 - [Deployment](#deployment)
 - [Friends](#friends)
 
-##Getting Started
+## Getting Started
 
     $ gem install chemistrykit
     $ ckit new framework_name
@@ -35,9 +35,9 @@ This will generate a beaker file (a.k.a. test script) with the name you provide 
 
 This will run ckit and execute your beakers. By default it will run the tests locally by default. But you can change where the tests run and all other relevant bits in `config.yaml` file detailed below.
 
-##Building a Test Suite
+## Building a Test Suite
 
-###Spec Discovery
+### Spec Discovery
 
 ChemistryKit is built on top of RSpec. All specs are in the _beaker_ directory and end in _beaker.rb. Rather than being discovered via class or file name as some systems they are by identified by tag.
 
@@ -75,12 +75,12 @@ During development it is often helpful to just run a specific beaker, this can b
 
     ckit brew --beakers=beakers/wip_beaker.rb
 
-####Special Tags
+#### Special Tags
 There are some tags that can be used to control various aspects of the harness. The following are supported:
 
 - `public: SOME_VALUE` - If you are running your harness against sauce labs, then you can control how the permissions are set for a particular beaker according to the visibility options detailed at the bottom of [this page](https://saucelabs.com/docs/additional-config). For example if you wanted a test to be private you could add `public: 'private'` to your beaker tags.
 
-###Formula Loading
+### Formula Loading
 Code in the `formula` directory can be used to build out page objects and helper functions to facilitate your testing. The files are loaded in a particular way:
 
 - Files in any `lib` directory are loaded before other directories.
@@ -89,7 +89,7 @@ Code in the `formula` directory can be used to build out page objects and helper
 
 So for example if you have a `alpha_page.rb` file in your formulas directory that depends on a `helpers.rb` file, then you best put the `helpers.rb` file in the `lib` directory so it is loaded before the file that depends on it.
 
-###Chemists! The Users of your System Under Test
+### Chemists! The Users of your System Under Test
 With ChemistryKit we made it simple to encapsulate data about a particular user that is "using" your application that you are testing. We call them chemists. When you create a new test harness there will be a `chemists` folder that contains an empty `chemists.csv` file with only the words `key` and `type` at the top. In this folder you can create any number of files with arbitrary user data, **just make sure to include the `key` and`type` headings!** such as:
 
     /chemists/my_valid_users.csv
@@ -151,7 +151,7 @@ Inside your formula. COOL!
 
 The FormulaLab will handle the heavy lifting of assembling your formula with a driver and correct chemist (if the formula needs one). Also note that the specific instance of chemist is cached so that any changes your formula makes to the chemist is reflected in other formulas that use it.
 
-###Catalysts! Driving Tests with Data
+### Catalysts! Driving Tests with Data
 In addition to using **Chemists** to mix data into your test barness, you can also use **Catalysts** simple key-value stores that can be populated from a CSV file. Formulas can set and get a catalyst or use the `catalyize` method to directly inject the data into the formula by file name. Once you have a catalyst, simply access the values by their keys:
 
 ```Ruby
@@ -172,10 +172,10 @@ module Formulas
 end
 ```
 
-###Execution Order
+### Execution Order
 Chemistry Kit executes specs in a random order. This is intentional. Knowing the order a spec will be executed in allows for dependencies between them to creep in. Sometimes unintentionally. By having them go in a random order parallelization becomes a much easier.
 
-###Before and After
+### Before and After
 Chemistry Kit uses the 4-phase model for scripts with a chunk of code that gets run before and after each method. By default, it does nothing more than launch a browser instance that your configuration says you want. If you want to do something more than that, just add it to your spec.
 
 ```ruby
@@ -186,26 +186,26 @@ end
 
 You can even nest them inside different describe/context blocks and they will get executed from the outside-in.
 
-###Reporting and CI Integration
+### Reporting and CI Integration
 Each run of Chemistry Kit saves logging and test output to the _evidence_ directory. And in there will be the full set of JUnit XML files that may be consumed by your CI as well as a `final_results.html` report file with a full review of all the tests.
 
 Assets generated by Selenium (logs, screenshots, etc.) are stored in a subfolder with a name matching the describe block in your beaker, slugifyed like: `my_beaker_name`. This is to provide some organization but also allow the integration with jenkins using [this plugin](https://wiki.jenkins-ci.org/display/JENKINS/JUnit+Attachments+Plugin).
 
-##Configuration
+## Configuration
 ChemistryKit is configured by default with a `config.yaml` file that is created for you when you scaffold out a test harness. Relevant configuration options are detailed below:
 
-###Basic Options
+### Basic Options
 - `base_url:` The base url of your app, stored to the ENV for access in your beakers and formulas.
 - `retries_on_failure:` Defaults to 1, set the number of times a test should be retried on failure
 - `concurrency:` You may override the default concurrency of 1 to run the tests in parallel
 
 - `screenshot_on_fail` By default false, set to true to download a screenshot of the failure (supported by sauce labs for now.)
 
-###Selenium Connect Options
+### Selenium Connect Options
 
 `selenium_connect:` Options under this node override the defaults for the [Selenium Connect](https://github.com/arrgyle/selenium-connect) gem. See that documentation for specifics.
 
-###Basic Auth Options
+### Basic Auth Options
 `basic_auth:` Options under this node allow you to configure your test harness to authenticate prior to executing a test. This is helpful for testing against restricted development environments. The options include:
 
 - `username:` The username to access your site with basic HTTP authentication.
@@ -213,23 +213,23 @@ ChemistryKit is configured by default with a `config.yaml` file that is created 
 - `http_path:` An HTTP end-point loaded before each test run to cache the credentials for the test run.
 - `https_path:` An HTTPS end-point loaded before each test run to cache the credentials for the test run.
 
-###Split Testing Options
+### Split Testing Options
 `split_testing:` Currently ChemistryKit supports opting out of [Optimizely](https://www.optimizely.com/) A/B testing. The available options are:
 
 - `provider:` Currently only `optimizely` is supported.
 - `opt_out:` A value of `true` will opt you out of the A/B testing
 
 
-##Command Line Usage
+## Command Line Usage
 
-###new
+### new
 Creates a new ChemistryKit project.
 
 Usage:
 
     ckit new [NAME]
 
-###brew
+### brew
 Executes your test cases.
 
 Usage:
@@ -247,7 +247,7 @@ Available options for the `brew` command:
 -x, --retry [INT]           How many times should a failing test be retried.
 ```
 
-###generate forumla
+### generate forumla
 Creates a new boilerplate formula object.
 
 Usage:
@@ -255,21 +255,21 @@ Usage:
     ckit generate formula [NAME]
 
 
-###generate beaker
+### generate beaker
 Creates a new boilerplate beaker object.
 
 Usage:
 
     ckit generate beaker [NAME]
 
-###tags
+### tags
 Lists all the tags you have used in your beakers.
 
 Usage:
 
     ckit tags
 
-##Contribution Guidelines
+## Contribution Guidelines
 
 This project conforms to the [neverstopbuilding/craftsmanship](https://github.com/neverstopbuilding/craftsmanship) guidelines. Please see them for details on:
 - Branching theory
@@ -278,10 +278,10 @@ This project conforms to the [neverstopbuilding/craftsmanship](https://github.co
 
 Most importantly, submit your pull requests to the `develop` branch.
 
-###Check out the user group!
+### Check out the user group!
 [https://groups.google.com/forum/#!forum/chemistrykit-users](https://groups.google.com/forum/#!forum/chemistrykit-users)
 
-###It's simple
+### It's simple
 
 1. Create a feature branch from develop: `git checkout -b feature/myfeature develop` or `git flow feature start myfeature`
 2. Do something awesome.
@@ -301,7 +301,7 @@ All issues and questions related to this project should be logged using the [git
 
     ckit
 
-##Deployment
+## Deployment
 The release process is rather automated, just use one rake task with the new version number:
 
     rake release_start['2.1.0']


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
